### PR TITLE
add generatorOptions to ignore extra secrets being generated for logi…

### DIFF
--- a/components/login-template/base/kustomization.yaml
+++ b/components/login-template/base/kustomization.yaml
@@ -14,3 +14,7 @@ secretGenerator:
     disableNameSuffixHash: true
   files:
     - login/providers.html 
+
+generatorOptions:
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous    


### PR DESCRIPTION
the OAuth app got flagged as unsynced as the secrets generated by OpenShift do not carry over the IgnoreExtranous annotation. This change will put it on the initial secrets in `openshift-config` which get copied to the ones in `openshift-authentication`